### PR TITLE
Updated AsyncUdpSocket use to GCDAsyncUdpSocket

### DIFF
--- a/Sources/BridgeServices/BridgeFinder/Scanner/SSDPScanner.swift
+++ b/Sources/BridgeServices/BridgeFinder/Scanner/SSDPScanner.swift
@@ -9,29 +9,32 @@
 import Foundation
 import CocoaAsyncSocket
 
-class SSDPScanner: NSObject, Scanner, AsyncUdpSocketDelegate {
-    private let ssdpSocket: AsyncUdpSocket
-    private var results = [String]()
+class SSDPScanner: NSObject, Scanner, GCDAsyncUdpSocketDelegate {
+    private let ssdpSocket: GCDAsyncUdpSocket
+    private let delegateQueue = DispatchQueue(label: "com.blowfishlab.SwiftyHue.ssdpscanner")
+    private var results = Set<String>()
     weak var delegate: ScannerDelegate?
 
     required init(delegate: ScannerDelegate? = nil) {
-        ssdpSocket = AsyncUdpSocket(delegate: nil)
         self.delegate = delegate
+        ssdpSocket = GCDAsyncUdpSocket()
         super.init()
-        ssdpSocket.setDelegate(self)
+        ssdpSocket.setDelegate(self, delegateQueue: delegateQueue)
     }
 
     func start() {
         do {
             try ssdpSocket.enableBroadcast(true)
-            let searchData = "M-SEARCH * HTTP/1.1\r\nHOST: 239.255.255.250:1900\r\nMan: \"ssdp:discover\"\r\nST: ssdp:all\r\n\r\n".data(using: String.Encoding.utf8)
+            let searchData = "M-SEARCH * HTTP/1.1\r\nHOST: 239.255.255.250:1900\r\nMan: \"ssdp:discover\"\r\nST: ssdp:all\r\n\r\n".data(using: .utf8)!
             let host = "239.255.255.250"
             let port: UInt16 = 1900
             // listen 102 error: https://github.com/robbiehanson/CocoaAsyncSocket/issues/376
             try ssdpSocket.bind(toPort: 0)
+
             ssdpSocket.send(searchData, toHost: host, port: port, withTimeout: 5, tag: 1)
+            try ssdpSocket.beginReceiving()
+
             let receiveTimeout: TimeInterval = 5
-            ssdpSocket.receive(withTimeout: receiveTimeout, tag: 1)
             Timer.scheduledTimer(timeInterval: receiveTimeout, target: self, selector: #selector(SSDPScanner.stop), userInfo: self, repeats: false)
 
         } catch let error as NSError {
@@ -41,21 +44,25 @@ class SSDPScanner: NSObject, Scanner, AsyncUdpSocketDelegate {
 
     @objc func stop() {
         ssdpSocket.close()
-        delegate?.scanner(self, didFinishWithResults: results)
+        let ips = Array(results)
+        delegate?.scanner(self, didFinishWithResults: ips)
     }
 
-    // MARK: - AsyncUdpSocketDelegate
-
-    func onUdpSocket(_ sock: AsyncUdpSocket!, didReceive data: Data!, withTag tag: Int, fromHost host: String!, port: UInt16) -> Bool {
-        guard let result = NSString(data: data, encoding: String.Encoding.ascii.rawValue) else {
+    // MARK: - GCDAsyncUdpSocketDelegate
+    func udpSocket(_ sock: GCDAsyncUdpSocket, didReceive data: Data, fromAddress address: Data, withFilterContext: AnyObject?){
+        guard let result = String(data: data, encoding:.ascii) else {
             print("Could not decode ssdp data")
-            return true
+            return
         }
 
         if result.contains("IpBridge") {
-            results.append(host)
+            var host: NSString?
+            var port: UInt16 = 0
+
+            GCDAsyncUdpSocket.getHost(&host, port: &port, fromAddress: address)
+            if let host = host as? String{
+                results.insert(host)
+            }
         }
-        
-        return true
     }
 }


### PR DESCRIPTION
Per the warning message in the build of CocoaAsyncSocket:

```
'AsyncSocket' is deprecated: The RunLoop versions of CocoaAsyncSocket are deprecated and will be removed in a future release. Please migrate to GCDAsyncSocket.
```