### PR TITLE
in case of a success message don't print error

### DIFF
--- a/Sources/Base/BridgeResourceModels/Error.swift
+++ b/Sources/Base/BridgeResourceModels/Error.swift
@@ -32,6 +32,10 @@ public class HueError: NSError, JSONDecodable {
     
     public required init?(json: JSON) {
 
+        if let _: Any = "success" <~~ json {
+            return nil
+        }
+
         guard let type: Int = "error.type" <~~ json,
             let address: String = "error.address" <~~ json,
             let errorDescription: String = "error.description" <~~ json


### PR DESCRIPTION
In case of a success message "Can't create Error Object from JSON" is printed.
Check, if json is "success" and return nil without any printing.